### PR TITLE
Add matchFont in Unsupported Features

### DIFF
--- a/docs/docs/getting-started/web.mdx
+++ b/docs/docs/getting-started/web.mdx
@@ -161,6 +161,7 @@ To request these features, please submit [a feature request on GitHub](https://g
 * `PathEffectFactory.MakeCompose()`
 * `PathFactory.MakeFromText()`
 * `ShaderFilter`
+* `matchFont`
 
 **Unplanned**
 


### PR DESCRIPTION
Hello Skia team. I really love using Skia. This is a great tool ever. :)

I found out matchFont is not implemented for Web yet so I added it to Unsupported Features in the installation guide for Web.

Do you have a plan to add this feature? because it's so powerful to handle multiple fonts :)

Thanks :)

![CleanShot 2024-03-21 at 02 15 41@2x](https://github.com/daehyeonmun2021/react-native-skia/assets/96194917/11e0dde2-874d-44de-b3bd-88841fdc8bee)